### PR TITLE
Fix autofill issue on ios

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zyda/react-otp-input",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "A fully customizable, one-time password input component for the web built with React",
   "main": "lib/index.js",
   "scripts": {

--- a/src/lib/index.jsx
+++ b/src/lib/index.jsx
@@ -101,7 +101,7 @@ class SingleOtpInput extends PureComponent {
             hasErrored && errorStyle
           )}
           type={this.getType()}
-          maxLength={this.props.numInputs}
+          maxLength={1}
           ref={this.input}
           disabled={isDisabled}
           value={value || ''}


### PR DESCRIPTION
Update maxLength prop to fix autofill issue on ios (ex: "form messages 1234" wasn't showing)
